### PR TITLE
fix(website): :bug: Fix the presigned URL for video preview in the Analysis view

### DIFF
--- a/source/website/src/views/Analysis.vue
+++ b/source/website/src/views/Analysis.vue
@@ -333,7 +333,8 @@
           const proxy_encode_key = 'private/assets/' + this.$route.params.asset_id + '/' + proxy_encode_filename
           key = proxy_encode_key
         }
-        const data = { "S3Bucket": bucket, "S3Key": key };
+        // The proxy file must always be taken by the data plane bucket, even if an external bucket is defined
+        const data = { "S3Bucket": this.DATAPLANE_BUCKET, "S3Key": key };
 
         // get presigned URL to video file in S3
         let apiName = 'mieDataplaneApi'


### PR DESCRIPTION
When an External bucket is defined in the MIE configuration, the pre-signed URL for the video preview must be generated using the data plane bucket instead of the external bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
