### PR TITLE
Change Cloudformation Template to match Media Insights Engine

### DIFF
--- a/deployment/aws-content-analysis.yaml
+++ b/deployment/aws-content-analysis.yaml
@@ -19,7 +19,7 @@ Parameters:
       - "r4.xlarge.search"
 
 Conditions:
-  EnableAnonymousData: !Equals [ !FindInMap [AnonymousData,SendAnonymousData,Data], Yes]
+  EnableAnonymousData: !Equals [ !FindInMap [AnonymousData,SendAnonymousData,Data], true]
 
 Mappings:
   MediaInsightsEngine:
@@ -34,7 +34,7 @@ Mappings:
       Version: "%%VERSION%%"
   AnonymousData:
     SendAnonymousData:
-      Data: Yes
+      Data: true
 
 Resources:
   # Deploy MIE Framework
@@ -51,10 +51,10 @@ Resources:
             - Version
           - "/media-insights-stack.template"
       Parameters:
-        DeployAnalyticsPipeline: Yes
-        DeployTestResources: No
+        DeployAnalyticsPipeline: true
+        DeployTestResources: false
         MaxConcurrentWorkflows: 5
-        EnableXrayTrace: Yes
+        EnableXrayTrace: true
         SendAnonymousData: !FindInMap [AnonymousData,SendAnonymousData,Data]
         SolutionId: SO0042
         SolutionVersion: "%%VERSION%%"


### PR DESCRIPTION
Description of changes:
At the moment, parameter values for media insights engine for `SendAnonymousData`, `DeployAnalyticsPipeline`, `DeployTestResources` and `EnableXrayTrace` are set to either `Yes` or `No`. Based on media insights engine documentation on https://github.com/aws-solutions/media-insights-on-aws, the values should be either `true` or `false`. Running with the current values would result in parameter errors and the media insights nested stack will fail (verified this in us-east-1 region). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
