### PR TITLE
downgrade package to fix es_client errors

### DIFF
--- a/source/consumer/requirements.txt
+++ b/source/consumer/requirements.txt
@@ -1,2 +1,2 @@
-elasticsearch==8.6.0
+elasticsearch==7.13.4
 requests-aws4auth==1.1.1


### PR DESCRIPTION
*[Issue #85]*

*Description of changes:*
Downgrade elasticsearch package in ElasticSearchConsumerLambda function back to v7 to fix lambda handler errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
